### PR TITLE
Make map friendly to gray scale

### DIFF
--- a/LimitedPrintMap.html
+++ b/LimitedPrintMap.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+
+<title>Mapping the Mexican Midwest</title>
+
+<style>
+#map {
+    width: 800px;
+    height:475px;
+}
+</style>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
+   integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+   crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
+   integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
+   crossorigin=""></script>
+<script src='https://api.mapbox.com/mapbox.js/plugins/leaflet-omnivore/v0.2.0/leaflet-omnivore.min.js'></script>
+<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.0/papaparse.min.js"></script>
+</head>
+
+<body>
+
+
+
+<div id="map"></div>
+
+
+<script>
+var map = L.map('map').setView([39.0132371,-95.8484624], 6);
+L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.{ext}', {
+  attribution: '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors. Map created by Bryan Winston.',
+  ext: 'png'
+}).addTo(map);
+
+var layerControl = L.control.layers(null, null).addTo(map);
+
+var communities = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-communities-dataset.csv', function(csvString) {
+   var community = Papa.parse(csvString, {header: true, dynamicTyping: true}).data;
+
+   for (var i in community) {
+      var row = community[i];
+
+      var marker = L.circleMarker([row.latitude, row.longitude], {
+        opacity: 1
+      }).bindPopup("<b>Community: </b>" + row.place + "</br>" + "<b>Type: </b>" + row.type);
+      
+      marker.addTo(map);
+    }
+
+});
+
+var churches = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-churches-dataset.csv', function(csvString) {
+   var greenIcon = new L.Icon({
+  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41]
+});
+   var church = Papa.parse(csvString, {header: true, dynamicTyping: true}).data;
+
+   for (var i in church) {
+      var row = church[i];
+
+      var marker = L.marker([row.latitude, row.longitude], {
+        icon: greenIcon
+      }).bindPopup("<b>Name: </b>" + row.church + "</br>" + "<b>Denomination: </b>" + row.type + "</br>" + "<b>Nationality: </b>" + row.nationality);
+      
+      marker.addTo(map);
+    }
+
+});
+
+var consOrgs = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-consular-organizations-dataset.csv', function(csvString) {
+   var redIcon = new L.Icon({
+  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41]
+});
+   var consular = Papa.parse(csvString, {header: true, dynamicTyping: true}).data;
+
+   for (var i in consular) {
+      var row = consular[i];
+
+      var marker = L.marker([row.latitude, row.longitude], {
+        icon: redIcon
+      }).bindPopup("<b>Organization: </b>" + row.name + "</br>" + "<b>Type: </b>" + row.type);
+      
+      marker.addTo(map);
+    }
+
+});
+
+
+
+</script>
+
+</body>
+
+</html>

--- a/LimitedPrintMap.html
+++ b/LimitedPrintMap.html
@@ -11,6 +11,22 @@
     width: 800px;
     height:475px;
 }
+
+.leaflet-overlay-pane g {
+  opacity: .1;
+}
+
+rect {
+  fill: #666;
+  stroke: #ccc;
+  stroke-width: 1px;
+}
+
+.cross rect {
+  fill: #333;
+  stroke-width: 0px;
+}
+
 </style>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
    integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
@@ -37,6 +53,38 @@ L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}
   ext: 'png'
 }).addTo(map);
 
+const icon = {
+  height: 12,
+  width: 12
+};
+
+const svgSquare = L.divIcon({
+  html: `<svg 
+  width="${icon.width}" 
+  height="${icon.height}" 
+  version="1.1"
+  xmnls="http://www.w3.org/2000/svg">
+  <rect width="${icon.width/2}" height="${icon.height/2}" />
+</svg>`,
+  className: "",
+  iconSize: [icon.width, icon.height],
+  iconAnchor: [icon.width/2, icon.height/2]
+})
+
+const svgCross = L.divIcon({
+  html: `<svg 
+  width="${icon.width}" 
+  height="${icon.height}" 
+  version="1.1"
+  xmnls="http://www.w3.org/2000/svg">
+  <rect y="${icon.height/3}" width="${icon.width}" height="${icon.height/3}" />
+  <rect x="${icon.width/3}" width="${icon.width/3}" height="${icon.height}" />
+</svg>`,
+  className: "cross",
+  iconSize: [icon.width, icon.height],
+  iconAnchor: [icon.width/2, icon.height/2]
+});
+
 const communities = L.layerGroup();
 const churches = L.layerGroup();
 const consOrgs = L.layerGroup();
@@ -54,7 +102,9 @@ $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-m
       var row = community[i];
 
       var marker = L.circleMarker([row.latitude, row.longitude], {
-        opacity: 1
+        stroke: false,
+        fillColor: "#000000",
+        fillOpacity: 1
       }).bindPopup("<b>Community: </b>" + row.place + "</br>" + "<b>Type: </b>" + row.type);
       
       communities.addLayer(marker);
@@ -63,21 +113,13 @@ $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-m
 });
 
 $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-churches-dataset.csv', function(csvString) {
-   var greenIcon = new L.Icon({
-  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
-  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41]
-});
    var church = Papa.parse(csvString, {header: true, dynamicTyping: true}).data;
 
    for (var i in church) {
       var row = church[i];
 
       var marker = L.marker([row.latitude, row.longitude], {
-        icon: greenIcon
+        icon: svgCross,
       }).bindPopup("<b>Name: </b>" + row.church + "</br>" + "<b>Denomination: </b>" + row.type + "</br>" + "<b>Nationality: </b>" + row.nationality);
       
       //marker.addTo(map);
@@ -87,21 +129,13 @@ $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-m
 });
 
 $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-consular-organizations-dataset.csv', function(csvString) {
-   var redIcon = new L.Icon({
-  iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
-  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41]
-});
    var consular = Papa.parse(csvString, {header: true, dynamicTyping: true}).data;
 
    for (var i in consular) {
       var row = consular[i];
 
       var marker = L.marker([row.latitude, row.longitude], {
-        icon: redIcon
+        icon: svgSquare,
       }).bindPopup("<b>Organization: </b>" + row.name + "</br>" + "<b>Type: </b>" + row.type);
       
     consOrgs.addLayer(marker);

--- a/LimitedPrintMap.html
+++ b/LimitedPrintMap.html
@@ -37,9 +37,17 @@ L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}
   ext: 'png'
 }).addTo(map);
 
-var layerControl = L.control.layers(null, null).addTo(map);
+const communities = L.layerGroup();
+const churches = L.layerGroup();
+const consOrgs = L.layerGroup();
 
-var communities = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-communities-dataset.csv', function(csvString) {
+var layerControl = L.control.layers(null, {
+  "Communities": communities,
+  "Churches": churches,
+  "Consular Organizations": consOrgs,
+}).addTo(map);
+
+$.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-communities-dataset.csv', function(csvString) {
    var community = Papa.parse(csvString, {header: true, dynamicTyping: true}).data;
 
    for (var i in community) {
@@ -49,12 +57,12 @@ var communities = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/map
         opacity: 1
       }).bindPopup("<b>Community: </b>" + row.place + "</br>" + "<b>Type: </b>" + row.type);
       
-      marker.addTo(map);
+      communities.addLayer(marker);
     }
 
 });
 
-var churches = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-churches-dataset.csv', function(csvString) {
+$.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-churches-dataset.csv', function(csvString) {
    var greenIcon = new L.Icon({
   iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
   shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
@@ -72,12 +80,13 @@ var churches = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mappin
         icon: greenIcon
       }).bindPopup("<b>Name: </b>" + row.church + "</br>" + "<b>Denomination: </b>" + row.type + "</br>" + "<b>Nationality: </b>" + row.nationality);
       
-      marker.addTo(map);
+      //marker.addTo(map);
+      churches.addLayer(marker);
     }
 
 });
 
-var consOrgs = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-consular-organizations-dataset.csv', function(csvString) {
+$.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mapping-the-mexican-midwest/master/mexican-consular-organizations-dataset.csv', function(csvString) {
    var redIcon = new L.Icon({
   iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
   shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
@@ -95,7 +104,7 @@ var consOrgs = $.get('https://raw.githubusercontent.com/bryanwinston-ddhi/mappin
         icon: redIcon
       }).bindPopup("<b>Organization: </b>" + row.name + "</br>" + "<b>Type: </b>" + row.type);
       
-      marker.addTo(map);
+    consOrgs.addLayer(marker);
     }
 
 });


### PR DESCRIPTION
I've removed all the color from map (save the links at the bottom), and I've replaced the teardrops with a tiny square and a tiny cross. If you enlarge the circleMarker, you can make the lightgray "community" wash take up more space.

If you want to play w/ the sizes, etc., I've named everything pretty clearly and defined the two icons in terms of a single height and width (12px for both), so you can make one adjustment that effects both icons. Circlemarkers I did not redefine, other than making them completely black w/ no outline and then using some CSS trickery to make them very light gray w/ no visible overlap between them.